### PR TITLE
Patch: rewrite `useFloating`

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,3 +31,28 @@ export function styleObjectToString(styleObject: Partial<ElementCSSInlineStyle['
  * Useful as a default value for optional callbacks.
  */
 export function noop() {}
+
+/**
+ * A function that creates a simple publish/subscribe mechanism.
+ */
+export function createPubSub() {
+	const map = new Map<string, Array<(data: unknown) => void>>();
+
+	return {
+		emit(event: string, data: unknown) {
+			map.get(event)?.forEach((handler) => handler(data));
+		},
+		on(event: string, listener: (data: unknown) => void) {
+			map.set(event, [...(map.get(event) || []), listener]);
+		},
+		off(event: string, listener: (data: unknown) => void) {
+			map.set(event, map.get(event)?.filter((l) => l !== listener) || []);
+		}
+	};
+}
+/**
+ * Generates a unique identifier.
+ */
+export function generateId() {
+	return `floating-ui-${Math.random().toString(36).slice(2, 6)}`;
+}


### PR DESCRIPTION
This PR rewrites the `useFloating` hook to have a nearly identical API with React to allow easier porting of other hooks. (This is something I realized while writing the `useHover` hook) The API is nearly identical, it just work a little different internally and now returns a `context` object.