### PR TITLE
Added the ability to define elements upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `useFloating` Svelte hook acts as a controller for all other Floating UI Sve
 <script lang="ts">
 	import { useFloating } from '@skeletonlabs/floating-ui-svelte';
 
-	const floating = useFloating({ elements });
+	const floating = useFloating();
 </script>
 
 <button bind:this="{floating.elements.reference}">Reference</button>
@@ -138,8 +138,8 @@ This will ensure all event handlers will be registered rather being overruled by
 	const interactions = useInteractions([hover]);
 </script>
 
-<button {...interactions.getReferenceProps()}>Reference</button>
-<div {...interactions.getFloatingProps()}>Tooltip</div>
+<button bind:this="{floating.elements.reference}"  {...interactions.getReferenceProps()}>Reference</button>
+<div bind:this="{floating.elements.floating}" style="{floating.floatingStyles}" {...interactions.getFloatingProps()}>Tooltip</div>
 ```
 
 #### Options
@@ -174,8 +174,8 @@ This will ensure all event handlers will be registered rather being overruled by
 	const interactions = useInteractions([role]);
 </script>
 
-<button {...interactions.getReferenceProps()}>Reference</button>
-<div {...interactions.getFloatingProps()}>Tooltip</div>
+<button bind:this="{floating.elements.reference}" {...interactions.getReferenceProps()}>Reference</button>
+<div bind:this="{floating.elements.floating}" style="{floating.floatingStyles}" {...interactions.getFloatingProps()}>Tooltip</div>
 ```
 
 #### Options
@@ -203,13 +203,7 @@ Renders a customizable `<svg>` pointing arrow triangle inside the floating eleme
 
 	let arrowRef: HTMLElement | null = $state(null);
 
-	const elements: { reference: HTMLElement | null; floating: HTMLElement | null } = $state({
-		reference: null,
-		floating: null
-	});
-
 	const floating = useFloating({
-		elements,
 		get middleware() {
 			return [
 				offset(10),
@@ -219,8 +213,8 @@ Renders a customizable `<svg>` pointing arrow triangle inside the floating eleme
 	});
 </script>
 
-<button bind:this={elements.reference}>Reference</button>
-<div bind:this={elements.floating} style={floating.floatingStyles} class="floating">
+<button bind:this="{floating.elements.reference}">Reference</button>
+<div bind:this="{floating.elements.floating}" style="{floating.floatingStyles}" class="floating">
 	<div>Floating</div>
 	<FloatingArrow
 		bind:ref={arrowRef}

--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ The `useFloating` Svelte hook acts as a controller for all other Floating UI Sve
 <script lang="ts">
 	import { useFloating } from '@skeletonlabs/floating-ui-svelte';
 
-	const elements: { reference: HTMLElement | null; floating: HTMLElement | null } = $state({ reference: null, floating: null });
 	const floating = useFloating({ elements });
 </script>
 
-<button bind:this="{elements.reference}">Reference</button>
-<div bind:this="{elements.floating}" style="{floating.floatingStyles}" class="floating">Floating</div>
+<button bind:this="{floating.elements.reference}">Reference</button>
+<div bind:this="{floating.elements.floating}" style="{floating.floatingStyles}" class="floating">Floating</div>
 ```
 
 > [!WARNING]
@@ -85,6 +84,7 @@ The `useFloating` Svelte hook acts as a controller for all other Floating UI Sve
 | middlewareData | Additional data from middleware. | MiddlewareData  |
 | isPositioned   | The boolean that let you know if the floating element has been positioned. | boolean |
 | floatingStyles | CSS styles to apply to the floating element to position it. | string |
+| elements | The reference and floating elements. | FloatingElements |
 | update | The function to update floating position manually. | () => void |
 | context | Context object containing internal logic to alter the behavior of the floating element. | FloatingContext |
 

--- a/src/lib/hooks/useFloating/index.svelte.ts
+++ b/src/lib/hooks/useFloating/index.svelte.ts
@@ -151,6 +151,11 @@ interface UseFloatingReturn extends UseFloatingData {
 	readonly floatingStyles: string;
 
 	/**
+	 * The reference and floating elements.
+	 */
+	readonly elements: FloatingElements;
+
+	/**
 	 * Updates the floating element position.
 	 */
 	readonly update: () => Promise<void>;
@@ -165,8 +170,8 @@ interface UseFloatingReturn extends UseFloatingData {
  * Hook for managing floating elements.
  */
 function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
-	const floating = $derived(options.elements?.floating);
-	const reference = $derived(options.elements?.reference);
+	const elements = $state(options.elements ?? {});
+	const { floating, reference } = $derived(elements);
 	const placement = $derived(options.placement ?? 'bottom');
 	const strategy = $derived(options.strategy ?? 'absolute');
 	const middleware = $derived(options.middleware ?? []);
@@ -275,6 +280,14 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 	};
 
 	$effect.pre(() => {
+		elements.reference = options.elements?.reference;
+	});
+
+	$effect.pre(() => {
+		elements.floating = options.elements?.floating;
+	});
+
+	$effect.pre(() => {
 		if (open || !state.isPositioned) {
 			return;
 		}
@@ -320,6 +333,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		get floatingStyles() {
 			return floatingStyles;
 		},
+		elements,
 		update,
 		context
 	};

--- a/src/lib/hooks/useFloating/index.svelte.ts
+++ b/src/lib/hooks/useFloating/index.svelte.ts
@@ -171,8 +171,8 @@ interface UseFloatingReturn extends UseFloatingData {
  */
 function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 	const elements = $state(options.elements ?? {});
-	const floating = $state(elements.floating);
-	const reference = $state(elements.reference);
+	const floating = $derived(elements.floating);
+	const reference = $derived(elements.reference);
 	const placement = $derived(options.placement ?? 'bottom');
 	const strategy = $derived(options.strategy ?? 'absolute');
 	const middleware = $derived(options.middleware ?? []);

--- a/src/lib/hooks/useFloating/index.svelte.ts
+++ b/src/lib/hooks/useFloating/index.svelte.ts
@@ -38,7 +38,7 @@ interface UseFloatingOptions {
 	readonly open?: boolean;
 
 	/**
-	 * Event handler that can be invoked whenever the open state changes.
+	 * Callback that is called whenever the open state changes.
 	 */
 	readonly onOpenChange?: (open: boolean, event?: Event, reason?: OpenChangeReason) => void;
 
@@ -68,8 +68,8 @@ interface UseFloatingOptions {
 	readonly transform?: boolean;
 
 	/**
-	 * The reference and floating elements.
-	 * @default undefined
+	 * Object containing the floating and reference elements.
+	 * @default {}
 	 */
 	readonly elements?: FloatingElements;
 
@@ -126,16 +126,46 @@ interface FloatingEvents {
 }
 
 interface ContextData {
+	/**
+	 * The latest even that caused the open state to change.
+	 */
 	openEvent?: Event;
 }
 
 interface FloatingContext extends UseFloatingData {
+	/**
+	 * Represents the open/close state of the floating element.
+	 */
 	open: boolean;
+
+	/**
+	 * Callback that is called whenever the open state changes.
+	 */
 	onOpenChange(open: boolean, event?: Event, reason?: OpenChangeReason): void;
+
+	/**
+	 * Events for other hooks to consume.
+	 */
 	events: FloatingEvents;
+
+	/**
+	 * Arbitrary data produced and consumer by other hooks.
+	 */
 	data: ContextData;
+
+	/**
+	 * The id for the reference element
+	 */
 	nodeId: string | undefined;
+
+	/**
+	 * The id for the floating element
+	 */
 	floatingId: string;
+
+	/**
+	 * Object containing the floating and reference elements.
+	 */
 	elements: FloatingElements;
 }
 

--- a/src/lib/hooks/useFloating/index.svelte.ts
+++ b/src/lib/hooks/useFloating/index.svelte.ts
@@ -170,16 +170,16 @@ interface UseFloatingReturn extends UseFloatingData {
  * Hook for managing floating elements.
  */
 function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
+	const {
+		placement = 'bottom',
+		strategy = 'absolute',
+		middleware = [],
+		transform = true,
+		open = true,
+		onOpenChange = noop,
+		whileElementsMounted
+	} = $derived(options);
 	const elements = $state(options.elements ?? {});
-	const floating = $derived(elements.floating);
-	const reference = $derived(elements.reference);
-	const placement = $derived(options.placement ?? 'bottom');
-	const strategy = $derived(options.strategy ?? 'absolute');
-	const middleware = $derived(options.middleware ?? []);
-	const transform = $derived(options.transform ?? true);
-	const open = $derived(options.open ?? true);
-	const onOpenChange = $derived(options.onOpenChange ?? noop);
-	const whileElementsMounted = $derived(options.whileElementsMounted);
 	const floatingStyles = $derived.by(() => {
 		const initialStyles = {
 			position: strategy,
@@ -187,18 +187,18 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 			top: '0px'
 		};
 
-		if (!floating) {
+		if (!elements.floating) {
 			return styleObjectToString(initialStyles);
 		}
 
-		const x = roundByDPR(floating, state.x);
-		const y = roundByDPR(floating, state.y);
+		const x = roundByDPR(elements.floating, state.x);
+		const y = roundByDPR(elements.floating, state.y);
 
 		if (transform) {
 			return styleObjectToString({
 				...initialStyles,
 				transform: `translate(${x}px, ${y}px)`,
-				...(getDPR(floating) >= 1.5 && { willChange: 'transform' })
+				...(getDPR(elements.floating) >= 1.5 && { willChange: 'transform' })
 			});
 		}
 
@@ -249,18 +249,11 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		nodeId: undefined,
 		// TODO: Ensure nodeId works the same way as in @floating-ui/react
 		floatingId: generateId(),
-		elements: {
-			get floating() {
-				return floating;
-			},
-			get reference() {
-				return reference;
-			}
-		}
+		elements
 	});
 
 	const update = async () => {
-		if (!floating || !reference) {
+		if (!elements.floating || !elements.reference) {
 			return;
 		}
 
@@ -270,7 +263,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 			middleware
 		};
 
-		const position = await computePosition(reference, floating, config);
+		const position = await computePosition(elements.reference, elements.floating, config);
 
 		state.x = position.x;
 		state.y = position.y;
@@ -297,7 +290,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 	});
 
 	$effect.pre(() => {
-		if (!floating || !reference) {
+		if (!elements.floating || !elements.reference) {
 			return;
 		}
 
@@ -306,7 +299,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 			return;
 		}
 
-		return whileElementsMounted(reference, floating, update);
+		return whileElementsMounted(elements.reference, elements.floating, update);
 	});
 
 	return {

--- a/src/lib/hooks/useFloating/index.svelte.ts
+++ b/src/lib/hooks/useFloating/index.svelte.ts
@@ -171,7 +171,8 @@ interface UseFloatingReturn extends UseFloatingData {
  */
 function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 	const elements = $state(options.elements ?? {});
-	const { floating, reference } = $derived(elements);
+	const floating = $state(elements.floating);
+	const reference = $state(elements.reference);
 	const placement = $derived(options.placement ?? 'bottom');
 	const strategy = $derived(options.strategy ?? 'absolute');
 	const middleware = $derived(options.middleware ?? []);

--- a/src/lib/hooks/useFloating/index.test.svelte.ts
+++ b/src/lib/hooks/useFloating/index.test.svelte.ts
@@ -105,22 +105,6 @@ describe('useFloating', () => {
 			expect(floating.floatingStyles).toContain('transform: translate(0px, 0px)');
 		});
 	});
-	// This test is not working, I honestly don't know why. All I know is that the code does indeed function as expected.
-	// it_in_effect('updates `floatingStyles` on DPR change.', async () => {
-	// 	window.devicePixelRatio = 1;
-
-	// 	const floating = useFloating(test_config());
-
-	// 	await vi.waitFor(() => {
-	// 		expect(floating.floatingStyles).not.toContain('willChange: transform');
-	// 	});
-
-	// 	window.devicePixelRatio = 2;
-
-	// 	await vi.waitFor(() => {
-	// 		expect(floating.floatingStyles).toContain('willChange: transform');
-	// 	});
-	// });
 	it_in_effect('updates `isPositioned` when position is computed', async () => {
 		const floating = useFloating({
 			...test_config(),
@@ -228,6 +212,29 @@ describe('useFloating', () => {
 			expect(floating.floatingStyles).toContain('transform: translate(0px, 0px)');
 		});
 	});
+	it_in_effect('fallbacks to default ({}) when `elements` is set to `undefined`', async () => {
+		let elements: UseFloatingOptions['elements'] | undefined = $state({
+			reference: document.createElement('div'),
+			floating: document.createElement('div')
+		});
+
+		const floating = useFloating({
+			...test_config(),
+			get elements() {
+				return elements;
+			}
+		});
+
+		await vi.waitFor(() => {
+			expect(floating.elements).toEqual(elements);
+		});
+
+		elements = undefined;
+
+		await vi.waitFor(() => {
+			expect(floating.elements).toEqual({});
+		});
+	});
 	it_in_effect(
 		'calls `whileElementsMounted` when `reference` and `floating` are mounted',
 		async () => {
@@ -296,6 +303,26 @@ describe('useFloating', () => {
 
 		await vi.waitFor(() => {
 			expect(floating.middlewareData).toEqual({ test: { content: 'Content' } });
+		});
+	});
+	it_in_effect('allows elements to be defined upstream', async () => {
+		const floating = useFloating();
+
+		await vi.waitFor(() => {
+			expect(floating.elements.reference).toBeUndefined();
+			expect(floating.elements.floating).toBeUndefined();
+		});
+
+		floating.elements.reference = document.createElement('div');
+
+		await vi.waitFor(() => {
+			expect(floating.elements.reference).toBeInstanceOf(HTMLElement);
+		});
+
+		floating.elements.floating = document.createElement('div');
+
+		await vi.waitFor(() => {
+			expect(floating.elements.floating).toBeInstanceOf(HTMLElement);
 		});
 	});
 });

--- a/src/routes/tooltips/Example.svelte
+++ b/src/routes/tooltips/Example.svelte
@@ -14,11 +14,7 @@
 
 	// State
 	let open = $state(false);
-
-	// Element References
 	let elemArrow: HTMLElement | null = $state(null);
-	let elemReference: HTMLElement | null = $state(null);
-	let elemFloating: HTMLElement | null = $state(null);
 
 	// Use Floating
 	const floating = useFloating({
@@ -28,14 +24,6 @@
 		},
 		onOpenChange: (v) => (open = v),
 		placement: 'top',
-		elements: {
-			get reference() {
-				return elemReference;
-			},
-			get floating() {
-				return elemFloating;
-			}
-		},
 		get middleware() {
 			return [offset(10), flip(), elemArrow && arrow({ element: elemArrow })];
 		}
@@ -49,12 +37,16 @@
 
 <div>
 	<!-- Reference Element -->
-	<button bind:this={elemReference} {...interactions.getReferenceProps()} class="btn-cta">
+	<button
+		bind:this={floating.elements.reference}
+		{...interactions.getReferenceProps()}
+		class="btn-cta"
+	>
 		Hover Me
 	</button>
 	<!-- Floating Element -->
 	<div
-		bind:this={elemFloating}
+		bind:this={floating.elements.floating}
 		style={floating.floatingStyles}
 		{...interactions.getFloatingProps()}
 		class="floating"


### PR DESCRIPTION
I'm sure Chris will be happy with this :)

To show what this does:

*Before*
```html
<script lang="ts">
	import { useFloating } from '@skeletonlabs/floating-ui-svelte';

	const elements: { reference: HTMLElement | null; floating: HTMLElement | null } = $state({ reference: null, floating: null });
	const floating = useFloating({ elements });
</script>

<button bind:this="{elements.reference}">Reference</button>
<div bind:this="{elements.floating}" style="{floating.floatingStyles}" class="floating">Floating</div>
```

*After*
```html
<script lang="ts">
	import { useFloating } from '@skeletonlabs/floating-ui-svelte';

	const floating = useFloating();
</script>

<button bind:this="{floating.elements.reference}">Reference</button>
<div bind:this="{floating.elements.floating}" style="{floating.floatingStyles}" class="floating">Floating</div>
```

QOL improvement. Just less boilerplate.

Ofcourse it's still possible to define elements through the options, in case of an external reference. For most use cases this will be nicer.

