### PR TITLE
Update FloatingArrow.svelte

### DIFF
--- a/src/lib/components/FloatingArrow/FloatingArrow.svelte
+++ b/src/lib/components/FloatingArrow/FloatingArrow.svelte
@@ -92,7 +92,7 @@
 	width={isCustomShape ? width : width + computedStrokeWidth}
 	height={width}
 	viewBox={`0 0 ${width} ${height > width ? height : width}`}
-	aria-hidden
+	aria-hidden="true"
 	style={styleObjectToString({
 		position: 'absolute',
 		pointerEvents: 'none',


### PR DESCRIPTION
Fix the `aria-hidden` a11y warning introduced due to the new version of Svelte.