### PR TITLE
Add useInteractions to the documentation website

### DIFF
--- a/src/docs/components/Navigation/Navigation.svelte
+++ b/src/docs/components/Navigation/Navigation.svelte
@@ -10,7 +10,7 @@
 	import IconContextMenus from 'lucide-svelte/icons/square-menu';
 	// Icons (API)
 	import IconUseFloating from 'lucide-svelte/icons/cloud';
-	// import IconUseInteractions from 'lucide-svelte/icons/pointer';
+	import IconUseInteractions from 'lucide-svelte/icons/pointer';
 	// import IconUseHover from 'lucide-svelte/icons/square-mouse-pointer';
 	// import IconUseClick from 'lucide-svelte/icons/mouse-pointer-2';
 	// import IconUseRole from 'lucide-svelte/icons/person-standing';
@@ -40,8 +40,8 @@
 		{
 			label: 'API Reference',
 			links: [
-				{ icon: IconUseFloating, href: '/api/use-floating', label: 'useFloating' }
-				// { icon: IconUseInteractions, href: '/api/use-interactions', label: 'useInteractions' },
+				{ icon: IconUseFloating, href: '/api/use-floating', label: 'useFloating' },
+				{ icon: IconUseInteractions, href: '/api/use-interactions', label: 'useInteractions' }
 				// { icon: IconUseHover, href: '/api/use-hover', label: 'useHover' },
 				// { icon: IconUseClick, href: '/api/use-click', label: 'useClick' },
 				// { icon: IconUseRole, href: '/api/use-role', label: 'useRole' },

--- a/src/routes/(inner)/api/use-interactions/+page.svelte
+++ b/src/routes/(inner)/api/use-interactions/+page.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import CodeBlock from '$docs/components/CodeBlock/CodeBlock.svelte';
+	import Table from '$docs/components/Table/Table.svelte';
+	import { tableReturns } from './data.js';
+</script>
+
+<div class="space-y-10">
+	<!-- Header -->
+	<header class="card card-gradient space-y-8">
+		<h1 class="h1"><span>useInteractions</span></h1>
+		<p>A hook to merge or compose interaction event handlers together.</p>
+		<CodeBlock
+			lang="ts"
+			code={`import { useInteractions } from '@skeletonlabs/floating-ui-svelte';`}
+		/>
+	</header>
+	<!-- Usage -->
+	<section class="space-y-8">
+		<h2 class="h2">Usage</h2>
+		<p>
+			The <code class="code">useInteractions</code> Svelte hook allows you to consume multiple interactions.
+			It ensures that event listeners from different hooks are properly registered instead of being overruled
+			by one another.
+		</p>
+		<CodeBlock
+			lang="ts"
+			code={`
+import { useFloating, useInteractions, useHover, useFocus } from '@skeletonlabs/floating-ui-svelte';
+
+const floating = useFloating();
+
+const hover = useHover(floating.context);
+const focus = useFocus(floating.context);
+
+const interactions = useInteractions([hover, focus]);
+`}
+		/>
+		<CodeBlock
+			lang="svelte"
+			code={`
+<!-- Reference Element -->
+<div {...interactions.getReferenceProps()}">
+	Reference
+</div>
+
+<!-- Floating Element -->
+<div {...interactions.getFloatingProps()}>
+	Floating
+</div>
+		`}
+		/>
+		<p>
+			When you want to apply an event handler to an element that uses a props getter, make sure to
+			pass it through the getter instead of applying it directly:
+		</p>
+		<CodeBlock
+			lang="svelte"
+			code={`
+<!-- Incorrect -->
+<div {...interactions.getReferenceProps()} onclick={/* event handler */}>Reference</div>
+
+<!-- Correct -->
+<div {...interactions.getReferenceProps({ onclick: /* event handler */})}>Reference</div>
+		`}
+		/>
+		<p>
+			This will ensure all event handlers will be registered rather being overruled by each-other.
+		</p>
+	</section>
+	<!-- Table: Returns -->
+	<section class="space-y-8">
+		<h2 class="h2">Returns</h2>
+		<Table data={tableReturns} />
+	</section>
+	<!-- Compare -->
+	<section class="space-y-8">
+		<h2 class="h2">Compare</h2>
+		<!-- prettier-ignore -->
+		<p>
+			Compare to <a class="anchor" href="https://floating-ui.com/docs/useInteractions" target="_blank">Floating UI React</a>.
+		</p>
+	</section>
+</div>

--- a/src/routes/(inner)/api/use-interactions/data.ts
+++ b/src/routes/(inner)/api/use-interactions/data.ts
@@ -1,0 +1,22 @@
+// Hook: useInteractions
+
+import type { TableData } from '$docs/types.js';
+
+// Returns
+export const tableReturns: TableData[] = [
+	{
+		property: `getReferenceProps`,
+		description: `The merged attributes for the reference element.`,
+		type: `(userProps?: HTMLAttributes) => Record<string, unknown>`
+	},
+	{
+		property: `getFloatingProps`,
+		description: `The merged attributes for the floating element.`,
+		type: `(userProps?: HTMLAttributes) => Record<string, unknown>`
+	},
+	{
+		property: `getItemProps`,
+		description: `The merged attributes for when dealing with a list inside the floating element.`,
+		type: `(userProps?: HTMLAttributes & ExtendedUserProps) => Record<string, unknown>`
+	}
+];


### PR DESCRIPTION
I tried to clarify this part a bit compared to the README:
<img width="1253" alt="image" src="https://github.com/skeletonlabs/floating-ui-svelte/assets/34682147/aeab63b7-33c4-4421-93ef-2bb9beafddb1">

I used svelte as the CodeBlock language instead of html to improve highlighting

#60 