### PR TITLE
Chore/use floating missing internals

### DIFF
--- a/src/lib/hooks/useFloating/index.svelte.ts
+++ b/src/lib/hooks/useFloating/index.svelte.ts
@@ -79,6 +79,12 @@ interface UseFloatingOptions {
 		floating: FloatingElement,
 		update: () => void,
 	) => () => void;
+
+	/**
+	 * Unique node id when using `FloatingTree`.
+	 * @default undefined
+	 */
+	nodeId?: string;
 }
 
 interface UseFloatingData {
@@ -206,6 +212,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		open = true,
 		onOpenChange: unstableOnOpenChange = noop,
 		whileElementsMounted,
+		nodeId,
 	} = $derived(options);
 	const floatingStyles = $derived.by(() => {
 		const initialStyles = {
@@ -255,6 +262,14 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 	});
 
 	const context: FloatingContext = $state({
+		data,
+		events,
+		elements,
+		onOpenChange,
+		floatingId: useId(),
+		get nodeId() {
+			return nodeId;
+		},
 		get x() {
 			return state.x;
 		},
@@ -276,15 +291,6 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		get open() {
 			return open;
 		},
-		get onOpenChange() {
-			return onOpenChange;
-		},
-		events,
-		data,
-		// TODO: Ensure nodeId works the same way as in @floating-ui/react
-		nodeId: undefined,
-		floatingId: useId(),
-		elements,
 	});
 
 	const update = async () => {
@@ -338,6 +344,9 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 	});
 
 	return {
+		update,
+		context,
+		elements,
 		get x() {
 			return state.x;
 		},
@@ -362,9 +371,6 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		get floatingStyles() {
 			return floatingStyles;
 		},
-		elements,
-		update,
-		context,
 	};
 }
 

--- a/src/lib/hooks/useFloating/index.test.svelte.ts
+++ b/src/lib/hooks/useFloating/index.test.svelte.ts
@@ -873,5 +873,24 @@ describe('useFloating', () => {
 				});
 			}),
 		);
+		it(
+			'updates nodeId reactively',
+			withEffect(async () => {
+				let nodeId = $state(useId());
+				const floating = useFloating({
+					get nodeId() {
+						return nodeId;
+					},
+				});
+
+				expect(floating.context.nodeId).toBe(nodeId);
+
+				nodeId = useId();
+
+				await vi.waitFor(() => {
+					expect(floating.context.nodeId).toBe(nodeId);
+				});
+			}),
+		);
 	});
 });

--- a/src/routes/(inner)/api/use-floating/data.ts
+++ b/src/routes/(inner)/api/use-floating/data.ts
@@ -44,13 +44,19 @@ export const tableOptions: TableData[] = [
 		property: `elements`,
 		description: `The reference and floating elements.`,
 		type: `FloatingElements`,
-		default: ``,
+		default: `{}`,
 	},
 	{
 		property: `whileElementsMounted`,
 		description: `Callback to handle mounting/unmounting of the elements.`,
-		type: `(reference: ReferenceElement, floating: FloatingElement, update: () => void) => () => void`,
-		default: ``,
+		type: `((reference: ReferenceElement, floating: FloatingElement, update: () => void) => () => void) | undefined`,
+		default: `undefined`,
+	},
+	{
+		property: 'nodeId',
+		description: 'A unique node ID for the floating element when using a `FloatingTree`.',
+		type: 'string | undefined',
+		default: 'undefined',
 	},
 ];
 


### PR DESCRIPTION
Adds a missing `onOpenChange` interceptor function that was causin some bugs with `useHover` (and probably other hooks in the future). Also added `nodeId` as an option.