### PR TITLE
Add unit to arrowX and arrowY

### DIFF
--- a/src/lib/components/FloatingArrow/FloatingArrow.svelte
+++ b/src/lib/components/FloatingArrow/FloatingArrow.svelte
@@ -60,8 +60,8 @@
 		return alignment === 'end' ? 'right' : 'left';
 	});
 
-	const arrowX = $derived(arrow?.x != null ? staticOffset || arrow.x : '');
-	const arrowY = $derived(arrow?.y != null ? staticOffset || arrow.y : '');
+	const arrowX = $derived(arrow?.x != null ? staticOffset || `${arrow.x}px` : '');
+	const arrowY = $derived(arrow?.y != null ? staticOffset || `${arrow.y}px` : '');
 
 	const dValue = $derived(
 		d ||


### PR DESCRIPTION
Chrome seems to add px to lengths without a unit, but Firefox does not. This results in the arrow being positioned incorrectly on Firefox

I'm not sure how staticOffset should be handled.

Fixes skeletonlabs/floating-ui-svelte#74