### PR TITLE
chore: changesets and CI tweaks

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,10 +1,10 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-	"changelog": "@changesets/cli/changelog",
+	"changelog": ["@changesets/cli/changelog", { "repo": "skeletonlabs/floating-ui-svelte" }],
 	"commit": false,
 	"fixed": [],
 	"linked": [],
-	"access": "restricted",
+	"access": "public",
 	"baseBranch": "dev",
 	"updateInternalDependencies": "patch",
 	"ignore": []

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Merge main into dev after publish
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          git checkout dev
+          git merge main
+          git push

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"build:docs": "svelte-kit sync && vite build",
 		"build:package": "svelte-kit sync && svelte-package && publint",
 		"ci:publish": "pnpm build:package && changeset publish",
-		"publish": "pnpm build:package && changeset publish",
 		"test": "vitest run --coverage",
 		"test:watch": "vitest run --coverage --watch",
 		"format": "prettier --write .",


### PR DESCRIPTION
Added a repo reference to the changeset config and added a step for syncing `dev` back up with `main` after releases are published.