### PR TITLE
Docs: Add page titles

### DIFF
--- a/.changeset/cyan-guests-hear.md
+++ b/.changeset/cyan-guests-hear.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/floating-ui-svelte": patch
+---
+
+docs: Addition of page titles

--- a/.changeset/cyan-guests-hear.md
+++ b/.changeset/cyan-guests-hear.md
@@ -1,5 +1,0 @@
----
-"@skeletonlabs/floating-ui-svelte": patch
----
-
-docs: Addition of page titles

--- a/src/docs/components/CodeBlock/CodeBlock.svelte
+++ b/src/docs/components/CodeBlock/CodeBlock.svelte
@@ -13,6 +13,7 @@
 
 	// Process Language
 	const renderedCode = $derived(
+		// FIXME: https://github.com/sveltejs/eslint-plugin-svelte/issues/652
 		// eslint-disable-next-line svelte/valid-compile
 		$page.data.highlighter.codeToHtml(code.trim(), {
 			lang,

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,22 +2,23 @@
 	import { page } from '$app/stores';
 	import Logo from '$docs/components/Logo/Logo.svelte';
 
-	// FIXME: Remove when Svelte 5 supports $page,
-	// see: https://github.com/sveltejs/eslint-plugin-svelte/issues/652
+	// FIXME: https://github.com/sveltejs/eslint-plugin-svelte/issues/652
 	// eslint-disable-next-line svelte/valid-compile
-	const pageStatus = () => String($page.status);
-	// eslint-disable-next-line svelte/valid-compile
-	const pageErrorMessage = () => String($page.error!.message);
+	const status = $derived($page.status);
+	// elint-disable-next-line svelte/valid-compile
+	const message = $derived($page.error ? $page.error.message : 'Unknown error');
 </script>
 
-{#if $page}
-	<div class="h-screen flex justify-center items-center">
-		<div class="flex flex-col items-center space-y-8">
-			<Logo />
-			<h2 class="h2">
-				{pageStatus()} - {#if pageErrorMessage()}{pageErrorMessage()}{/if}
-			</h2>
-			<p>We're sorry, something went wrong.</p>
-		</div>
+<svelte:head>
+	<title>{status} | Floating UI Svelte</title>
+</svelte:head>
+
+<div class="h-screen flex justify-center items-center">
+	<div class="flex flex-col items-center space-y-8">
+		<Logo />
+		<h2 class="h2">
+			{status} - {message}
+		</h2>
+		<p>We're sorry, something went wrong.</p>
 	</div>
-{/if}
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,22 @@
 <script lang="ts">
 	// Stylesheets
 	import '../app.pcss';
+	import { page } from '$app/stores';
 
 	// Props
 	let { children } = $props();
+
+	const title = $derived.by(() => {
+		// FIXME: https://github.com/sveltejs/eslint-plugin-svelte/issues/652
+		// eslint-disable-next-line svelte/valid-compile
+		const pathname = $page.url.pathname;
+		const titleRaw = pathname === '/' ? 'Home' : pathname.split('/').pop() ?? 'Floating UI Svelte';
+		return titleRaw.replace('-', ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	});
 </script>
+
+<svelte:head>
+	<title>{title} | Floating UI Svelte</title>
+</svelte:head>
 
 {@render children()}


### PR DESCRIPTION
## Linked Issue

Partially closes #65 

## Description

This adds a automatic title generation for every page. This makes it easier to easily spot which page you are on during development as well as make the prod site seem a little more professional.

## Changsets

We use [Changesets](https://github.com/changesets/changesets) to automatically create our changelog per each release. Any changes or additions to the Library assets in `/lib` must be documented with a new Changeset. This can be done as follows:

2. Navigate to the root of the project on your feature branch.
3. Run `pnpm changeset` to trigger the Changeset CLI.
4. Follow the instructions when prompted.
    - Changesets should be either `minor` or `patch`. Never `major`.
    - Prefix your Changeset description using: `docs:`, `feature:`, `chore:` or `bugfix:`.
5. Changeset `.md` files are added to the `/.changeset` directory.
6. Commit and push the the new changeset file.

## Checklist

Please read and apply all [contribution requirements](https://github.com/skeletonlabs/floating-ui-svelte/blob/chore/main/CONTRIBUTING.md).

- [x] PR targets the `dev` branch (NEVER `master`)
- [x] All website documentation is current with your changes
- [x] Ensure Prettier formatting is current - run `pnpm format`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm vitest`
- [x] Includes a changeset (if relevant; see above)
