### PR TITLE
Added caveat section for countering SSR layout shift

### DIFF
--- a/src/routes/(inner)/docs/getting-started/+page.svelte
+++ b/src/routes/(inner)/docs/getting-started/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import CodeBlock from '$docs/components/CodeBlock/CodeBlock.svelte';
+	import Ssr from './ssr.svelte';
+	import SsrRaw from './ssr.svelte?raw';
 </script>
 
 <div class="space-y-10">
@@ -42,6 +44,7 @@ npm install @skeletonlabs/floating-ui-svelte
 			class as shown below. Note that Floating UI does not take an opinionated stance on z-index
 			stacking.
 		</p>
+		<Ssr />
 		<CodeBlock
 			lang="css"
 			code={`
@@ -54,5 +57,20 @@ npm install @skeletonlabs/floating-ui-svelte
 		`}
 		/>
 		<CodeBlock lang="html" code={`<div class="floating">Some floating element.</div>`} />
+	</section>
+	<!-- Ceveats -->
+	<section class="space-y-8">
+		<h2 class="h2">Caveats</h2>
+		<h3 class="h3">SSR</h3>
+		<p>
+			When SSR is enabled and the floating element is visible upon pageload it will first be
+			positioned in the top left of your screen until the position is calculated. This is usually
+			not desirable.
+		</p>
+		<p>
+			To prevent this, you can utilize the <kbd class="kbd">isPositioned</kbd> prop returned from
+			the <kbd class="kbd"><a class="anchor" href="/api/use-floating">useFloating</a></kbd> hook:
+		</p>
+		<CodeBlock lang="svelte" code={SsrRaw} />
 	</section>
 </div>

--- a/src/routes/(inner)/docs/getting-started/ssr.svelte
+++ b/src/routes/(inner)/docs/getting-started/ssr.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { useFloating } from '@skeletonlabs/floating-ui-svelte';
+
+	const floating = useFloating();
+</script>
+
+<!-- Reference -->
+<div bind:this={floating.elements.reference}>Reference</div>
+
+<!-- Floating element is always rendered -->
+<div class="floating" bind:this={floating.elements.floating} style={floating.floatingStyles}>
+	<!-- The content of the floating element is shown once `isPositioned` is true -->
+	{#if floating.isPositioned}
+		Floating
+	{/if}
+</div>
+
+<style>
+	.floating {
+		width: max-content;
+		position: absolute;
+		top: 0;
+		left: 0;
+	}
+</style>


### PR DESCRIPTION
## Linked Issue

Closes #41

## Description

Adds a new Caveats section to the bottom of the getting-started page

## Changesets

We use [Changesets](https://github.com/changesets/changesets) to automatically create our changelog per each release. Any changes or additions to the Library assets in `/lib` must be documented with a new Changeset. This can be done as follows:

1. Navigate to the root of the project on your feature branch.
2. Run `pnpm changeset` to trigger the Changeset CLI.
3. Follow the instructions when prompted.
    - Changesets should be either `minor` or `patch`. Never `major`.
    - Prefix your Changeset description using: `feature:`, `chore:` or `bugfix:`.
4. Changeset `.md` files are added to the `/.changeset` directory.
5. Commit and push the the new changeset file.

## Checklist

Please read and apply all [contribution requirements](https://github.com/skeletonlabs/floating-ui-svelte/blob/chore/main/CONTRIBUTING.md).

- [ ] PR targets the `dev` branch (NEVER `master`)
- [ ] All website documentation is current with your changes
- [ ] Ensure Prettier formatting is current - run `pnpm format`
- [ ] Ensure ESLint linting is current - run `pnpm lint`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
