### PR TITLE
Chore: Fix improper examples

### DIFF
--- a/src/routes/(inner)/examples/popovers/Example.svelte
+++ b/src/routes/(inner)/examples/popovers/Example.svelte
@@ -47,23 +47,19 @@
 		Click Me
 	</button>
 	<!-- Floating Element -->
-	<div
-		bind:this={floating.elements.floating}
-		style={floating.floatingStyles}
-		{...interactions.getFloatingProps()}
-		class="floating"
-	>
-		{#if open}
-			<div
-				class="bg-surface-500 text-white p-8 max-w-sm rounded shadow-xl"
-				transition:fade={{ duration: 200 }}
-			>
-				<p>
-					You can press the <kbd class="kbd">esc</kbd> key or click outside to
-					<strong>*dismiss*</strong> this floating element.
-				</p>
-				<FloatingArrow bind:ref={elemArrow} context={floating.context} class="fill-surface-500" />
-			</div>
-		{/if}
-	</div>
+	{#if open}
+		<div
+			bind:this={floating.elements.floating}
+			style={floating.floatingStyles}
+			{...interactions.getFloatingProps()}
+			class="floating bg-surface-500 text-white p-8 max-w-sm rounded shadow-xl"
+			transition:fade={{ duration: 200 }}
+		>
+			<p>
+				You can press the <kbd class="kbd">esc</kbd> key or click outside to
+				<strong>*dismiss*</strong> this floating element.
+			</p>
+			<FloatingArrow bind:ref={elemArrow} context={floating.context} class="fill-surface-500" />
+		</div>
+	{/if}
 </div>

--- a/src/routes/(inner)/examples/tooltips/Example.svelte
+++ b/src/routes/(inner)/examples/tooltips/Example.svelte
@@ -47,23 +47,19 @@
 		Hover Me
 	</button>
 	<!-- Floating Element -->
-	<div
-		bind:this={floating.elements.floating}
-		style={floating.floatingStyles}
-		{...interactions.getFloatingProps()}
-		class="floating"
-	>
-		{#if open}
-			<div
-				class="bg-surface-500 text-white p-8 max-w-sm rounded shadow-xl"
-				transition:fade={{ duration: 200 }}
-			>
-				<p>
-					A <strong>floating element</strong> is one that floats on top of the UI without disrupting
-					the flow, like this one!
-				</p>
-				<FloatingArrow bind:ref={elemArrow} context={floating.context} class="fill-surface-500" />
-			</div>
-		{/if}
-	</div>
+	{#if open}
+		<div
+			bind:this={floating.elements.floating}
+			style={floating.floatingStyles}
+			{...interactions.getFloatingProps()}
+			class="floating bg-surface-500 text-white p-8 max-w-sm rounded shadow-xl"
+			transition:fade={{ duration: 200 }}
+		>
+			<p>
+				A <strong>floating element</strong> is one that floats on top of the UI without disrupting the
+				flow, like this one!
+			</p>
+			<FloatingArrow bind:ref={elemArrow} context={floating.context} class="fill-surface-500" />
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
## Linked Issue

No issue relevant

## Description

This moves the floating element into the `{#if open}` blocks to only calculate the position when elements are mounted which is best practise. 

## Changesets

We use [Changesets](https://github.com/changesets/changesets) to automatically create our changelog per each release. Any changes or additions to the Library assets in `/lib` must be documented with a new Changeset. This can be done as follows:

1. Navigate to the root of the project on your feature branch.
2. Run `pnpm changeset` to trigger the Changeset CLI.
3. Follow the instructions when prompted.
    - Changesets should be either `minor` or `patch`. Never `major`.
    - Prefix your Changeset description using: `feature:`, `chore:` or `bugfix:`.
4. Changeset `.md` files are added to the `/.changeset` directory.
5. Commit and push the the new changeset file.

## Checklist

Please read and apply all [contribution requirements](https://github.com/skeletonlabs/floating-ui-svelte/blob/chore/main/CONTRIBUTING.md).

- [x] PR targets the `dev` branch (NEVER `master`)
- [x] All website documentation is current with your changes
- [x] Ensure Prettier formatting is current - run `pnpm format`
- [x] Ensure ESLint linting is current - run `pnpm lint`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
