### PR TITLE
Rewrites the imports used in examples to the proper aliases

### DIFF
--- a/src/routes/(inner)/examples/popovers/Example.svelte
+++ b/src/routes/(inner)/examples/popovers/Example.svelte
@@ -11,7 +11,7 @@
 		useRole,
 		useDismiss,
 		useClick,
-	} from '$lib/index.js';
+	} from '@skeletonlabs/floating-ui-svelte';
 
 	// State
 	let open = $state(false);

--- a/src/routes/(inner)/examples/tooltips/Example.svelte
+++ b/src/routes/(inner)/examples/tooltips/Example.svelte
@@ -11,7 +11,7 @@
 		useInteractions,
 		useRole,
 		useDismiss,
-	} from '$lib/index.js';
+	} from '@skeletonlabs/floating-ui-svelte';
 
 	// State
 	let open = $state(false);


### PR DESCRIPTION
Rewrites the imports used in examples to the proper aliases