### PR TITLE
highlight is now mark, accepts a nested array for ranges

### DIFF
--- a/src/docs/components/CodeBlock/CodeBlock.svelte
+++ b/src/docs/components/CodeBlock/CodeBlock.svelte
@@ -6,11 +6,23 @@
 	interface Props {
 		code: string;
 		lang: BuiltinLanguage | SpecialLanguage;
-		highlight?: number | Array<number>;
+		mark?: Array<number | [number, number]>;
 	}
 
 	// Props
-	let { code, lang = 'text', highlight = [] }: Props = $props();
+	let { code, lang = 'text', mark = [] }: Props = $props();
+
+	const highlightedLineNumbers = $derived(
+		mark
+			.map((mark) => {
+				if (Array.isArray(mark)) {
+					const [start, end] = mark;
+					return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+				}
+				return mark;
+			})
+			.flat(),
+	);
 
 	// Process Language
 	const renderedCode = $derived(
@@ -29,8 +41,8 @@
 				 * This transformer adds the `highlighted` class to lines that are to be highlighted.
 				 */
 				{
-					line(node, line) {
-						if (!(Array.isArray(highlight) ? highlight : [highlight]).includes(line)) {
+					line(node, lineNumber) {
+						if (!highlightedLineNumbers.includes(lineNumber)) {
 							return;
 						}
 						this.addClassToHast(node, 'highlighted');


### PR DESCRIPTION
## Linked Issue

Closes #126 

## Description

- Renamed `highlight` to `mark` (same API as expressive code).
- `mark` now accepts a nested array that turns into a range.

Example:
`mark={[1,[3,5]}` highlights the following lines: `[1,3,4,5]`

## Changesets

We use [Changesets](https://github.com/changesets/changesets) to automatically create our changelog per each release. Any changes or additions to the Library assets in `/lib` must be documented with a new Changeset. This can be done as follows:

1. Navigate to the root of the project on your feature branch.
2. Run `pnpm changeset` to trigger the Changeset CLI.
3. Follow the instructions when prompted.
    - Changesets should be either `minor` or `patch`. Never `major`.
    - Prefix your Changeset description using: `feature:`, `chore:` or `bugfix:`.
4. Changeset `.md` files are added to the `/.changeset` directory.
5. Commit and push the the new changeset file.

## Checklist

Please read and apply all [contribution requirements](https://github.com/skeletonlabs/floating-ui-svelte/blob/chore/main/CONTRIBUTING.md).

- [x] PR targets the `dev` branch (NEVER `master`)
- [x] All website documentation is current with your changes
- [x] Ensure Prettier formatting is current - run `pnpm format`
- [x] Ensure ESLint linting is current - run `pnpm lint`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
