### PR TITLE
Chore: Remove `dev` branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
 	"fixed": [],
 	"linked": [],
 	"access": "public",
-	"baseBranch": "dev",
+	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"ignore": []
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ We use [Changesets](https://github.com/changesets/changesets) to automatically c
 
 Please read and apply all [contribution requirements](https://github.com/skeletonlabs/floating-ui-svelte/blob/chore/main/CONTRIBUTING.md).
 
-- [ ] PR targets the `dev` branch (NEVER `master`)
+- [ ] PR targets the `main` branch
 - [ ] All website documentation is current with your changes
 - [ ] Ensure Prettier formatting is current - run `pnpm format`
 - [ ] Ensure ESLint linting is current - run `pnpm lint`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,13 @@ on:
 
 env:
   node_version: 20
-  pnpm_version: 8
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: ${{ env.pnpm_version }}
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -28,9 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: ${{ env.pnpm_version }}
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -44,9 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: ${{ env.pnpm_version }}
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -60,9 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: ${{ env.pnpm_version }}
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -78,9 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: ${{ env.pnpm_version }}
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Merge main into dev after publish
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          git checkout dev
-          git merge main
-          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   node_version: 20
-  pnpm_version: 8
 
 jobs:
   release:
@@ -19,9 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v3
-        with:
-          version: ${{ env.pnpm_version }}
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+package-manager-strict=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,7 @@ The floating UI Svelte project is built using SvelteKit to handle both the docum
 
 ## Branch
 
-Floating UI Svelte uses two primary branches. All pull requests should be created again the `dev` branch.
-
-| Branch | Description | Pull Requests |
-| --- | --- | --- |
-| `dev` | The development branch. | Allowed |
-| `main` | The release branch. | Never |
+All pull requests should be created against the `main` branch.
 
 ### PR Branch Conventions
 

--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"type": "module"
+	"type": "module",
+	"packageManager": "pnpm@9.5.0"
 }


### PR DESCRIPTION
This PR prepares for the removal of the `dev` branch as it serves no purpose. Changesets are already kept on a seperate branch until release and we're only fighting against it by having a seperate branch.

What this PR does:
- Change `baseBranch` from `"dev"` to `"main"` in `.changeset/config.json`
- Remove `Merge main into dev after publish` step from `.github/workflows/release.yml`
- Remove "PR targets the `dev` branch (NEVER `main` branch)" from `.github/pull_request_template.md`