### PR TITLE
Bugfix: Fix package installations by removing `postinstall` lifecycle script.

### DIFF
--- a/.changeset/strong-parents-allow.md
+++ b/.changeset/strong-parents-allow.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/floating-ui-svelte": patch
+---
+
+Fix package installations by removing `postinstall` lifecycle script.

--- a/packages/floating-ui-svelte/package.json
+++ b/packages/floating-ui-svelte/package.json
@@ -6,7 +6,7 @@
 		"build:watch": "pnpm build --watch",
 		"test": "vitest run",
 		"test:watch": "pnpm test --watch",
-		"sync": "pnpm build"
+		"sync": "sveltekit-sync && pnpm build"
 	},
 	"files": ["dist"],
 	"sideEffects": false,

--- a/packages/floating-ui-svelte/package.json
+++ b/packages/floating-ui-svelte/package.json
@@ -6,7 +6,7 @@
 		"build:watch": "pnpm build --watch",
 		"test": "vitest run",
 		"test:watch": "pnpm test --watch",
-		"sync": "sveltekit-sync && pnpm build"
+		"sync": "svelte-kit sync && pnpm build"
 	},
 	"files": ["dist"],
 	"sideEffects": false,

--- a/packages/floating-ui-svelte/package.json
+++ b/packages/floating-ui-svelte/package.json
@@ -6,7 +6,6 @@
 		"build:watch": "pnpm build --watch",
 		"test": "vitest run",
 		"test:watch": "pnpm test --watch",
-		"postinstall": "svelte-kit sync",
 		"sync": "pnpm build"
 	},
 	"files": ["dist"],


### PR DESCRIPTION
Closes #155

My dumbass didn't know `postinstall` scripts also ran on the consumer side of things, my bad! This PR fixes that by removing the `postinstall` step from the published package.