### PR TITLE
Feature: adds translate option to the useFloating hook

### DIFF
--- a/packages/floating-ui-svelte/src/hooks/use-floating.svelte.ts
+++ b/packages/floating-ui-svelte/src/hooks/use-floating.svelte.ts
@@ -231,6 +231,28 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		whileElementsMounted,
 		nodeId,
 	} = $derived(options);
+
+	const state: UseFloatingData = $state({
+		x: 0,
+		y: 0,
+		strategy,
+		placement,
+		middlewareData: {},
+		isPositioned: false,
+	});
+
+	const origin = $derived.by(() => {
+		if (state.placement.startsWith("top"))
+			return state.placement.replace("top", "bottom");
+		if (state.placement.startsWith("bottom"))
+			return state.placement.replace("bottom", "top");
+		if (state.placement.startsWith("left"))
+			return state.placement.replace("left", "right");
+		if (state.placement.startsWith("right"))
+			return state.placement.replace("right", "left");
+		return state.placement;
+	});
+
 	const floatingStyles = $derived.by(() => {
 		const initialStyles = {
 			position: strategy,
@@ -249,6 +271,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 			return styleObjectToString({
 				...initialStyles,
 				translate: `${x}px ${y}px`,
+				"transform-origin": origin,
 				...(getDPR(elements.floating) >= 1.5 && { willChange: "transform" }),
 			});
 		}
@@ -257,6 +280,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 			return styleObjectToString({
 				...initialStyles,
 				transform: `translate(${x}px, ${y}px)`,
+				"transform-origin": origin,
 				...(getDPR(elements.floating) >= 1.5 && { willChange: "transform" }),
 			});
 		}
@@ -280,15 +304,6 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		events.emit("openchange", { open, event, reason });
 		unstableOnOpenChange(open, event, reason);
 	};
-
-	const state: UseFloatingData = $state({
-		x: 0,
-		y: 0,
-		strategy,
-		placement,
-		middlewareData: {},
-		isPositioned: false,
-	});
 
 	const context: FloatingContext = $state({
 		data,

--- a/packages/floating-ui-svelte/src/hooks/use-floating.svelte.ts
+++ b/packages/floating-ui-svelte/src/hooks/use-floating.svelte.ts
@@ -69,6 +69,13 @@ interface UseFloatingOptions {
 	transform?: boolean;
 
 	/**
+	 * Whether to use 'translate' instead of 'transform' to position the floating element.
+	 *
+	 * @default false
+	 */
+	translate?: boolean;
+
+	/**
 	 * Object containing the floating and reference elements.
 	 * @default {}
 	 */
@@ -218,6 +225,7 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 		strategy = "absolute",
 		middleware = [],
 		transform = true,
+		translate = false,
 		open = true,
 		onOpenChange: unstableOnOpenChange = noop,
 		whileElementsMounted,
@@ -236,6 +244,14 @@ function useFloating(options: UseFloatingOptions = {}): UseFloatingReturn {
 
 		const x = roundByDPR(elements.floating, state.x);
 		const y = roundByDPR(elements.floating, state.y);
+
+		if (translate) {
+			return styleObjectToString({
+				...initialStyles,
+				translate: `${x}px ${y}px`,
+				...(getDPR(elements.floating) >= 1.5 && { willChange: "transform" }),
+			});
+		}
 
 		if (transform) {
 			return styleObjectToString({

--- a/packages/floating-ui-svelte/test/hooks/use-floating.svelte.ts
+++ b/packages/floating-ui-svelte/test/hooks/use-floating.svelte.ts
@@ -162,6 +162,65 @@ describe("useFloating", () => {
 		);
 	});
 
+	describe("translate", () => {
+		it(
+			"can be set",
+			withRunes(async () => {
+				const translate = true;
+				const floating = useFloating({
+					elements: createElements(),
+					translate,
+				});
+
+				await vi.waitFor(() => {
+					expect(floating.floatingStyles).contain(
+						"translate: 0px 0px",
+					);
+				});
+			}),
+		);
+		it(
+			'defaults to "false"',
+			withRunes(async () => {
+				const floating = useFloating({
+					elements: createElements(),
+				});
+				await vi.waitFor(() => {
+					expect(floating.floatingStyles).contain(
+						"transform: translate(0px, 0px)",
+					);
+				});
+			}),
+		);
+		it(
+			"is reactive",
+			withRunes(async () => {
+				let translate = $state(true);
+
+				const floating = useFloating({
+					elements: createElements(),
+					get translate() {
+						return translate;
+					},
+				});
+
+				await vi.waitFor(() => {
+					expect(floating.floatingStyles).contain(
+						"translate: 0px 0px",
+					);
+				});
+
+				translate = false;
+
+				await vi.waitFor(() => {
+					expect(floating.floatingStyles).not.contain(
+						"translate: 0px 0px",
+					);
+				});
+			}),
+		);
+	});
+
 	describe("strategy", () => {
 		it(
 			"can be set",

--- a/packages/floating-ui-svelte/test/hooks/use-floating.svelte.ts
+++ b/packages/floating-ui-svelte/test/hooks/use-floating.svelte.ts
@@ -160,6 +160,35 @@ describe("useFloating", () => {
 				});
 			}),
 		);
+		it.each<{ placement: Placement; expected: Placement }>([
+			{ placement: "top", expected: "bottom" },
+			{ placement: "right", expected: "left" },
+			{ placement: "bottom", expected: "top" },
+			{ placement: "left", expected: "right" },
+
+			{ placement: "top-start", expected: "bottom-start" },
+			{ placement: "right-start", expected: "left-start" },
+			{ placement: "bottom-end", expected: "top-end" },
+			{ placement: "left-end", expected: "right-end" },
+		])("can be set to $placement", async ({ placement, expected }) => {
+			await withRunes(async () => {
+				const floating = useFloating({
+					placement,
+					elements: createElements(),
+				});
+
+				await vi.waitFor(() => {
+					expect(floating.floatingStyles).contain(
+						"transform: translate(0px, 0px)",
+					);
+				});
+
+				expect(floating.placement).toBe(placement);
+				expect(floating.floatingStyles).toContain(
+					`transform-origin: ${expected};`,
+				);
+			})();
+		});
 	});
 
 	describe("translate", () => {
@@ -173,9 +202,7 @@ describe("useFloating", () => {
 				});
 
 				await vi.waitFor(() => {
-					expect(floating.floatingStyles).contain(
-						"translate: 0px 0px",
-					);
+					expect(floating.floatingStyles).contain("translate: 0px 0px");
 				});
 			}),
 		);
@@ -205,17 +232,13 @@ describe("useFloating", () => {
 				});
 
 				await vi.waitFor(() => {
-					expect(floating.floatingStyles).contain(
-						"translate: 0px 0px",
-					);
+					expect(floating.floatingStyles).contain("translate: 0px 0px");
 				});
 
 				translate = false;
 
 				await vi.waitFor(() => {
-					expect(floating.floatingStyles).not.contain(
-						"translate: 0px 0px",
-					);
+					expect(floating.floatingStyles).not.contain("translate: 0px 0px");
 				});
 			}),
 		);
@@ -302,6 +325,7 @@ describe("useFloating", () => {
 			withRunes(() => {
 				const floating = useFloating();
 				expect(floating.placement).toBe("bottom");
+				expect(floating.floatingStyles).toContain("transform-origin: top;");
 			}),
 		);
 		it(


### PR DESCRIPTION
The use of the `transform` property for positionning might interfer with animation or make merging of state complex.

For example, using enter/exit animations such as svlete native `scale` transition overwrite the positionning during the transitions.

A workaround is to use absolute positioning, but this also causes positioning issues, and can be less performant / create content shift.

This PR propose to uses the `translate` property instead which has reach a relatively high level of support ([94-95%](https://caniuse.com/?search=translate)) in the recent years.

This also adds transform-origin when using translate/transform to facilitate animation and trnaisitons.